### PR TITLE
Fix: CMake didn't install `psarc-cl` correctly when running the install step

### DIFF
--- a/psarc-cl/CMakeLists.txt
+++ b/psarc-cl/CMakeLists.txt
@@ -64,4 +64,4 @@ add_custom_command(TARGET psarc-cl POST_BUILD
   COMMENT "Cleaning up stale executable: ${PSARC_CL_STALE_NAME}"
 )
 
-
+install(TARGETS psarc-cl DESTINATION "${CMAKE_INSTALL_BIN_DIR}")


### PR DESCRIPTION
This fix was just for a small oversight in the CMakeLists.txt file. Everything else installed correctly but the command line binary.